### PR TITLE
Use a wildcard lambda permission to allow invocation from eventbridge

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 SW Tools
+Copyright (c) 2022 SW Tools
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-eventbridge": "^3.43.0",
-        "@aws-sdk/client-lambda": "^3.43.0",
         "chrome-aws-lambda": "^10.1.0",
         "got": "^11.8.3",
         "http-status": "^1.5.0",
@@ -163,48 +162,6 @@
         "@aws-sdk/util-user-agent-node": "3.40.0",
         "@aws-sdk/util-utf8-browser": "3.37.0",
         "@aws-sdk/util-utf8-node": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.43.0.tgz",
-      "integrity": "sha512-6FuZfBJ40KlolUkjaz2WTtfQgvT5HigoV5O/VLqM3qFUpUsyQ+zjmm0y0QmfndAlK+8sI53yiKhBp/PMkAQgWw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.43.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
-        "@aws-sdk/fetch-http-handler": "3.40.0",
-        "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/invalid-dependency": "3.40.0",
-        "@aws-sdk/middleware-content-length": "3.40.0",
-        "@aws-sdk/middleware-host-header": "3.40.0",
-        "@aws-sdk/middleware-logger": "3.40.0",
-        "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/middleware-user-agent": "3.40.0",
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/node-http-handler": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/smithy-client": "3.41.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "@aws-sdk/util-base64-node": "3.37.0",
-        "@aws-sdk/util-body-length-browser": "3.37.0",
-        "@aws-sdk/util-body-length-node": "3.37.0",
-        "@aws-sdk/util-user-agent-browser": "3.40.0",
-        "@aws-sdk/util-user-agent-node": "3.40.0",
-        "@aws-sdk/util-utf8-browser": "3.37.0",
-        "@aws-sdk/util-utf8-node": "3.37.0",
-        "@aws-sdk/util-waiter": "3.40.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -870,19 +827,6 @@
       "integrity": "sha512-fUAgd7UTCULL36j9/vnXHxVhxvswnq23mYgTCIT8NQ7wHN30q2a89ym1e9DwGeQkJEBOkOcKLn6nsMsN7YQMDQ==",
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.37.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.40.0.tgz",
-      "integrity": "sha512-jdxwNEZdID49ZvyAnxaeNm5w2moIfMLOwj/q6TxKlxYoXMs16FQWkhyfGue0vEASzchS49ewbyt+KBqpT31Ebg==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -11199,45 +11143,6 @@
         "tslib": "^2.3.0"
       }
     },
-    "@aws-sdk/client-lambda": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.43.0.tgz",
-      "integrity": "sha512-6FuZfBJ40KlolUkjaz2WTtfQgvT5HigoV5O/VLqM3qFUpUsyQ+zjmm0y0QmfndAlK+8sI53yiKhBp/PMkAQgWw==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.43.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
-        "@aws-sdk/fetch-http-handler": "3.40.0",
-        "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/invalid-dependency": "3.40.0",
-        "@aws-sdk/middleware-content-length": "3.40.0",
-        "@aws-sdk/middleware-host-header": "3.40.0",
-        "@aws-sdk/middleware-logger": "3.40.0",
-        "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/middleware-user-agent": "3.40.0",
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/node-http-handler": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/smithy-client": "3.41.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "@aws-sdk/util-base64-node": "3.37.0",
-        "@aws-sdk/util-body-length-browser": "3.37.0",
-        "@aws-sdk/util-body-length-node": "3.37.0",
-        "@aws-sdk/util-user-agent-browser": "3.40.0",
-        "@aws-sdk/util-user-agent-node": "3.40.0",
-        "@aws-sdk/util-utf8-browser": "3.37.0",
-        "@aws-sdk/util-utf8-node": "3.37.0",
-        "@aws-sdk/util-waiter": "3.40.0",
-        "tslib": "^2.3.0"
-      }
-    },
     "@aws-sdk/client-sso": {
       "version": "3.41.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.41.0.tgz",
@@ -11774,16 +11679,6 @@
       "integrity": "sha512-fUAgd7UTCULL36j9/vnXHxVhxvswnq23mYgTCIT8NQ7wHN30q2a89ym1e9DwGeQkJEBOkOcKLn6nsMsN7YQMDQ==",
       "requires": {
         "@aws-sdk/util-buffer-from": "3.37.0",
-        "tslib": "^2.3.0"
-      }
-    },
-    "@aws-sdk/util-waiter": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.40.0.tgz",
-      "integrity": "sha512-jdxwNEZdID49ZvyAnxaeNm5w2moIfMLOwj/q6TxKlxYoXMs16FQWkhyfGue0vEASzchS49ewbyt+KBqpT31Ebg==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
         "tslib": "^2.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-eventbridge": "^3.43.0",
-    "@aws-sdk/client-lambda": "^3.43.0",
     "chrome-aws-lambda": "^10.1.0",
     "got": "^11.8.3",
     "http-status": "^1.5.0",

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,6 @@ Uses airline's API in an unsupported manner. Use at your own risk.
 ## TODO
 
 - Use something like dotenv to read authorization token so that user does not have to add it to their environment manually
-- After checkin remove the associated eventBridge rule, eventBridge trigger, and lambda permission
+- After checkin remove the associated eventBridge rule and eventBridge trigger
 - Try a publicly maintained Lambda layer for Puppeteer/Chromium (e.g. https://github.com/shelfio/chrome-aws-lambda-layer)
 - Use Serverless V3

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,6 +9,7 @@ provider:
   environment:
     AUTHORIZER_TOKEN: ${env:AUTHORIZER_TOKEN}
     ACCOUNT_ID: ${aws:accountId}
+    TRIGGER_SCHEDULED_CHECKIN_RULE_PREFIX: ${self:custom.rule_prefixes.trigger_scheduled_checkin}
   versionFunctions: false
   apiName: ${self:provider.stage}
   runtime: nodejs14.x
@@ -22,12 +23,7 @@ provider:
         - Effect: Allow
           Action:
             - events:*
-          Resource: arn:aws:events:${self:provider.region}:${aws:accountId}:rule/*
-        # ScheduleCheckin adds permission for created eventBridge rules to invoke HandleScheduledCheckin
-        - Effect: Allow
-          Action:
-            - lambda:AddPermission
-          Resource: arn:aws:lambda:${self:provider.region}:${aws:accountId}:function:checkin-service-prod-HandleScheduledCheckin
+          Resource: arn:aws:events:${self:provider.region}:${aws:accountId}:rule/${self:custom.rule_prefixes.trigger_scheduled_checkin}*
 
 layers:
   chromeAwsLambda:
@@ -48,6 +44,8 @@ custom:
       forceExclude:
         - chrome-aws-lambda
         - puppeteer-core
+  rule_prefixes:
+    trigger_scheduled_checkin: trigger-scheduled-checkin-
 
 functions:
   Authorizer:
@@ -83,3 +81,13 @@ functions:
     maximumRetryAttempts: 0
     layers:
       - { Ref: ChromeAwsLambdaLambdaLayer }
+
+Resources:
+  resources:
+    HandleScheduledCheckinPolicy:
+      Type: AWS::Lambda::Permission
+      Properties:
+        Action: lambda:InvokeFunction
+        FunctionName: !GetAtt HandleScheduledCheckin.Arn
+        Principal: events.amazonaws.com
+        SourceArn: arn:aws:events:${self:provider.region}:${aws:accountId}:rule/${self:custom.rule_prefixes.trigger_scheduled_checkin}*

--- a/serverless.yml
+++ b/serverless.yml
@@ -82,12 +82,12 @@ functions:
     layers:
       - { Ref: ChromeAwsLambdaLambdaLayer }
 
-Resources:
-  resources:
+resources:
+  Resources:
     HandleScheduledCheckinPolicy:
       Type: AWS::Lambda::Permission
       Properties:
         Action: lambda:InvokeFunction
-        FunctionName: !GetAtt HandleScheduledCheckin.Arn
+        FunctionName: !GetAtt HandleScheduledCheckinLambdaFunction.Arn
         Principal: events.amazonaws.com
         SourceArn: arn:aws:events:${self:provider.region}:${aws:accountId}:rule/${self:custom.rule_prefixes.trigger_scheduled_checkin}*

--- a/src/handlers/handle-scheduled-checkin.ts
+++ b/src/handlers/handle-scheduled-checkin.ts
@@ -10,7 +10,7 @@ import * as SwGenerateHeaders from '../lib/sw-generate-headers';
 /**
  * On scheduled checkin, check the user in.
  *
- * @todo also remove the associated eventBridge rule, eventBridge trigger, and lambda permission
+ * @todo also remove the associated eventBridge rule and eventBridge trigger
  */
 export async function handle(event: EventDetail.Detail) {
   let output: unknown;


### PR DESCRIPTION
After a lot of scheduled checkins, the Lambda role-baesd policy document will have too many statements and we'll get a PolicyLengthExceededException upon trying to add another permission for another eventbridge rule. Instead of adding a permission per rule, we just use a wildcard permission and apply it on deployment

Resolves #7 