### PR TITLE
Remove request.abort(), request is already handled.

### DIFF
--- a/src/lib/sw-generate-headers.ts
+++ b/src/lib/sw-generate-headers.ts
@@ -43,8 +43,6 @@ export async function generateHeaders(reservation: Reservation.Reservation) {
           headers[header] = allHeaders[header];
         }
       }
-
-      request.abort().catch(console.error);
     }
   });
 


### PR DESCRIPTION
I was gettin some errors in the logs during a checkin, see below:
```
2022-02-12T20:00:42.468Z	5b70e155-806f-4200-8a0c-d1c96e8c8f76	ERROR	Error: Request is already handled!
    at Object.assert (/opt/nodejs/node_modules/puppeteer-core/lib/cjs/puppeteer/common/assert.js:26:15)
    at HTTPRequest.abort (/opt/nodejs/node_modules/puppeteer-core/lib/cjs/puppeteer/common/HTTPRequest.js:311:21)
    at /var/task/src/handlers/handle-scheduled-checkin.js:306:21
    at /opt/nodejs/node_modules/puppeteer-core/lib/cjs/vendor/mitt/src/index.js:51:62
    at Array.map (<anonymous>)
    at Object.emit (/opt/nodejs/node_modules/puppeteer-core/lib/cjs/vendor/mitt/src/index.js:51:43)
    at Page.emit (/opt/nodejs/node_modules/puppeteer-core/lib/cjs/puppeteer/common/EventEmitter.js:72:22)
    at /opt/nodejs/node_modules/puppeteer-core/lib/cjs/puppeteer/common/Page.js:154:108
    at /opt/nodejs/node_modules/puppeteer-core/lib/cjs/vendor/mitt/src/index.js:51:62
    at Array.map (<anonymous>)
```

This is caused by the request.abort().catch(console.error). I believe the request is already handled by the code below:
```
page.on('request', request => {
  request.continue().catch(console.error);
});
```

I tested this locally, and it seems like I'm getting the headers just fine still, and it is still functional.