### PR TITLE
Remove sleep from sw-generate-headers

### DIFF
--- a/src/lib/sw-generate-headers.ts
+++ b/src/lib/sw-generate-headers.ts
@@ -62,11 +62,9 @@ export async function generateHeaders(reservation: Reservation.Reservation) {
 
   await page.click("button[type='submit']");
 
-  const waitMs = util.promisify(setTimeout);
-
-  // give time for network requests that will fetch the headers
-  // TODO: we would prefer to use page.waitForNetworkIdle() here but can't get it working in Lambda
-  await waitMs(10 * 1000);
+  await page.waitForNavigation({
+    waitUntil: ['networkidle0', 'load']
+  });
 
   await browser.close();
 

--- a/src/lib/sw-generate-headers.ts
+++ b/src/lib/sw-generate-headers.ts
@@ -46,8 +46,14 @@ export async function generateHeaders(reservation: Reservation.Reservation) {
     }
   });
 
+  // Only continue the request that have the header information we need
+  // Small optimization to save us from continuing on 100~ or so request
   page.on('request', request => {
-    request.continue().catch(console.error);
+    if (request.url().startsWith('https://mobile.southwest.com/')) {
+      request.continue().catch(console.error);
+    } else {
+      request.abort().catch(console.error);
+    }
   });
 
   await page.setRequestInterception(true);


### PR DESCRIPTION
Instead of sleeping, we will wait for the page to have 0 network request in the last 500 ms AND we get the page load event.

I've tested this on lambda to ensure it works. Total execution time is about 6000-6500 ms now! 

If we add the other optimization (see below), we take on average about 5000-6000ms.
```
  page.on('request', request => {
    if (request.url().startsWith('https://mobile.southwest.com/')) {
    request.continue().catch(console_1.default.error);
    } else {
    request.abort().catch(console_1.default.error);
    }
  });
```  

However, I am unsure if it impacts the contents of the headers (I don't think it does though...), but I left it out for now.

