### PR TITLE
Revert "Remove sleep from sw-generate-headers"

### DIFF
--- a/src/lib/sw-generate-headers.ts
+++ b/src/lib/sw-generate-headers.ts
@@ -46,14 +46,8 @@ export async function generateHeaders(reservation: Reservation.Reservation) {
     }
   });
 
-  // Only continue the request that have the header information we need
-  // Small optimization to save us from continuing on 100~ or so request
   page.on('request', request => {
-    if (request.url().startsWith('https://mobile.southwest.com/')) {
-      request.continue().catch(console.error);
-    } else {
-      request.abort().catch(console.error);
-    }
+    request.continue().catch(console.error);
   });
 
   await page.setRequestInterception(true);
@@ -68,9 +62,11 @@ export async function generateHeaders(reservation: Reservation.Reservation) {
 
   await page.click("button[type='submit']");
 
-  await page.waitForNavigation({
-    waitUntil: ['networkidle0', 'load']
-  });
+  const waitMs = util.promisify(setTimeout);
+
+  // give time for network requests that will fetch the headers
+  // TODO: we would prefer to use page.waitForNetworkIdle() here but can't get it working in Lambda
+  await waitMs(10 * 1000);
 
   await browser.close();
 


### PR DESCRIPTION
Reverts sw-tools/checkin-service#14

I'm seeing the following error. For some reason, the Lambda puppeteer seems to behave differently from the local version.

```
ERROR   Invoke Error    {"errorType":"TimeoutError","errorMessage":"Navigation timeout of 30000 ms exceeded","name":"TimeoutError","stack":["TimeoutError: Navigation timeout of 30000 ms exceeded","    at /opt/nodejs/node_modules/puppeteer-core/lib/cjs/puppeteer/common/LifecycleWatcher.js:106:111"]}
```

Note: it's possible I need to use a confirmation number and first and last name that are actually ready for checkin, but since this new implementation works locally but not in Lambda, I think we may need a new solution to the wait problem.

@aaron-pham correct me if I'm wrong. Reverting to the old wait solution for now, but would like to get rid of it.