### PR TITLE
Schedule checkin was failing to add to eventbridge rule

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,6 +11,7 @@ provider:
     ACCOUNT_ID: ${aws:accountId}
     TRIGGER_SCHEDULED_CHECKIN_RULE_PREFIX: ${self:custom.rule_prefixes.trigger_scheduled_checkin}
     SCHEDULED_CHECKIN_READY_QUEUE_URL: !Ref SqsScheduledCheckinReadyQueue
+    SCHEDULED_CHECKIN_READY_QUEUE_ARN: !GetAtt SqsScheduledCheckinReadyQueue.Arn
   versionFunctions: false
   apiName: ${self:provider.stage}
   runtime: nodejs14.x

--- a/src/handlers/schedule-checkin.ts
+++ b/src/handlers/schedule-checkin.ts
@@ -116,7 +116,7 @@ async function handleInternal(event: AWSLambda.APIGatewayProxyEvent) {
       eventBridge,
       ruleName,
       message,
-      targetArn: process.env.SCHEDULED_CHECKIN_READY_QUEUE_URL
+      targetArn: process.env.SCHEDULED_CHECKIN_READY_QUEUE_ARN
     });
 
     const checkinTime: CheckinTime = {


### PR DESCRIPTION
Hey, deployed the latest branch and noticed I was getting an error back.
```
fc3897c3-ca1f-4b88-bb12-9d65a1a8597b	ERROR	ValidationException: Parameter <URL> is not valid. Reason: Provided Arn is not in correct format.
    at deserializeAws_json1_1PutTargetsCommandError (/var/task/node_modules/@aws-sdk/client-eventbridge/dist-cjs/protocols/Aws_json1_1.js:3146:41)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async /var/task/node_modules/@aws-sdk/middleware-serde/dist-cjs/deserializerMiddleware.js:6:20
    at async /var/task/node_modules/@aws-sdk/middleware-signing/dist-cjs/middleware.js:11:20
    at async StandardRetryStrategy.retry (/var/task/node_modules/@aws-sdk/middleware-retry/dist-cjs/StandardRetryStrategy.js:51:46)
    at async /var/task/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:6:22
    at async handleInternal (/var/task/src/handlers/schedule-checkin.js:106:9)
    at async Runtime.handle [as handler] (/var/task/src/handlers/schedule-checkin.js:46:18) {
  __type: 'ValidationException',
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId: '92d5764f-829d-4784-93c1-da48ba161585',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  }
}
```

Updated and verified my rules are being created properly.