### PR TITLE
Modified retrieval of basic/advanced headers

### DIFF
--- a/src/lib/sw-generate-headers.ts
+++ b/src/lib/sw-generate-headers.ts
@@ -17,6 +17,8 @@ export async function generateHeaders(reservation: Reservation.Reservation) {
   });
   const page = await browser.newPage();
 
+  page.setDefaultNavigationTimeout(60000);
+
   await page.setUserAgent(
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
       '(KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36'


### PR DESCRIPTION
Added up to 10 retries for basicHeaders and advancedHeaders within handle-scheduled-checkin.ts

Increased puppeteer timeout to 60s within sw-generate-headers.ts